### PR TITLE
fix: change cache table properties

### DIFF
--- a/_cfn/test.yml
+++ b/_cfn/test.yml
@@ -7,13 +7,9 @@ Resources:
       AttributeDefinitions:
         - AttributeName: hash
           AttributeType: B
-        - AttributeName: payload
-          AttributeType: S
       KeySchema:
         - AttributeName: hash
           KeyType: HASH
-        - AttributeName: payload
-          KeyType: RANGE
       ProvisionedThroughput:
         ReadCapacityUnits: 1
         WriteCapacityUnits: 1

--- a/guanyu-core/lib/config.js
+++ b/guanyu-core/lib/config.js
@@ -17,7 +17,7 @@ nconf.use('memory')
     },
     STACK: {
       CACHE_TABLE_DISABLED: false,
-      CACHE_TABLE: 'GuanyuTestStack-TodShen-CacheTable-1J84RYWSJPEJ5',
+      CACHE_TABLE: 'GuanyuTestStack-TodShen-CacheTable-VG2PCHD6H2P7',
       SELF_ENDPOINT: 'http://localhost:3000/',
       SAMPLE_BUCKET: 'guanyuteststack-todshen-scanfilebucket-1n8n1ngt0plk',
     },


### PR DESCRIPTION
avoid two same hash value appear in dynamoDB